### PR TITLE
Reveal more generation errors (Test only)

### DIFF
--- a/src/tests/OpenApiGenerator.IntegrationTests.Twitch.Data/OpenApiGenerator.IntegrationTests.Twitch.Data.csproj
+++ b/src/tests/OpenApiGenerator.IntegrationTests.Twitch.Data/OpenApiGenerator.IntegrationTests.Twitch.Data.csproj
@@ -10,6 +10,8 @@
     <OpenApiGenerator_Namespace>OpenApiGenerator.IntegrationTests.Twitch</OpenApiGenerator_Namespace>
     <OpenApiGenerator_GenerateSdk>false</OpenApiGenerator_GenerateSdk>
     <OpenApiGenerator_GenerateModels>true</OpenApiGenerator_GenerateModels>
+    <OpenApiGenerator_GenerateMethods>true</OpenApiGenerator_GenerateMethods>
+    <OpenApiGenerator_GenerateConstructors>true</OpenApiGenerator_GenerateConstructors>
     <OpenApiGenerator_GenerateSuperTypeForJsonSerializerContext>true</OpenApiGenerator_GenerateSuperTypeForJsonSerializerContext>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR adds OpenApiGenerator_GenerateMethods and OpenApiGenerator_GenerateConstructors properties to OpenApiGenerator.IntegrationTests.Twitch.Data.csproj to reveal other generation errors.